### PR TITLE
iXRLibForUnreal, BASECLASS_STREAMLINE_DICTMETA_LOGTELEMETRYEVENT:  Me…

### DIFF
--- a/Source/IXRLib/Private/IXRBlueprintLibrary.cpp
+++ b/Source/IXRLib/Private/IXRBlueprintLibrary.cpp
@@ -50,7 +50,7 @@ void UIXRBlueprintLibrary::StartIXRLib_BFL()
 	int StatusIndex = Authenticate_BFL(UiXRDeveloperSettings::GetiXRConfig()->appID, UiXRDeveloperSettings::GetiXRConfig()->orgID,
 			FGuid::NewGuid().ToString(), UiXRDeveloperSettings::GetiXRConfig()->authSecret, 0);
 	UE_LOG(LogTemp, Warning, TEXT("Authenticated ====> %d"), StatusIndex);
-	LogInfo_BFL(TEXT("TestStr"));
+	LogInfo_BFL(TEXT("TestStr"), TEXT(""));
 }
 
 void UIXRBlueprintLibrary::iXRLibInitStart_BFL()
@@ -170,55 +170,57 @@ void UIXRBlueprintLibrary::UnCaptureTimeStamp_BFL()
 	UnCaptureTimeStamp();
 }
 
-int UIXRBlueprintLibrary::LogDebugSynchronous_BFL(const FString szText)
+int UIXRBlueprintLibrary::LogDebugSynchronous_BFL(const FString szText, const FString szdictMeta)
 {
-	return LogDebugSynchronous(FStringToChar16Ptr(szText));
+	return LogDebugSynchronous(FStringToChar16Ptr(szText), FStringToChar16Ptr(szdictMeta));
 }
 
-int UIXRBlueprintLibrary::LogDebug_BFL(const FString szText)
+int UIXRBlueprintLibrary::LogDebug_BFL(const FString szText, const FString szdictMeta)
 {
-	return LogDebug(FStringToChar16Ptr(szText));
+	return LogDebug(FStringToChar16Ptr(szText), FStringToChar16Ptr(szdictMeta));
 }
 
-int UIXRBlueprintLibrary::LogInfoSynchronous_BFL(const FString szText)
+int UIXRBlueprintLibrary::LogInfoSynchronous_BFL(const FString szText, const FString szdictMeta)
 {
-	return LogInfo(FStringToChar16Ptr(szText));
+	return LogInfo(FStringToChar16Ptr(szText), FStringToChar16Ptr(szdictMeta));
 }
 
-int UIXRBlueprintLibrary::LogInfo_BFL(const FString szText)
+int UIXRBlueprintLibrary::LogInfo_BFL(const FString szText, const FString szdictMeta)
 {
-	return LogInfo(FStringToChar16Ptr(szText));
+	return LogInfo(FStringToChar16Ptr(szText), FStringToChar16Ptr(szdictMeta));
 }
 
-int UIXRBlueprintLibrary::LogWarnSynchronous_BFL(const FString szText)
+int UIXRBlueprintLibrary::LogWarnSynchronous_BFL(const FString szText, const FString szdictMeta)
 {
-	return LogWarnSynchronous(FStringToChar16Ptr(szText));
+	return LogWarnSynchronous(FStringToChar16Ptr(szText), FStringToChar16Ptr(szdictMeta));
 }
 
-int UIXRBlueprintLibrary::LogWarn_BFL(const FString szText)
+int UIXRBlueprintLibrary::LogWarn_BFL(const FString szText, const FString szdictMeta)
 {
-	return LogWarn(FStringToChar16Ptr(szText));
+	return LogWarn(FStringToChar16Ptr(szText), FStringToChar16Ptr(szdictMeta));
 }
 
-int UIXRBlueprintLibrary::LogErrorSynchronous_BFL(const FString szText)
+int UIXRBlueprintLibrary::LogErrorSynchronous_BFL(const FString szText, const FString szdictMeta)
 {
-	return LogError(FStringToChar16Ptr(szText));
+	return LogError(FStringToChar16Ptr(szText), FStringToChar16Ptr(szdictMeta));
 }
 
-int UIXRBlueprintLibrary::LogError_BFL(const FString szText)
+int UIXRBlueprintLibrary::LogError_BFL(const FString szText, const FString szdictMeta)
 {
-	return LogError(FStringToChar16Ptr(szText));
+	return LogError(FStringToChar16Ptr(szText), FStringToChar16Ptr(szdictMeta));
 }
 
-int UIXRBlueprintLibrary::LogCriticalSynchronous_BFL(const FString szText)
+int UIXRBlueprintLibrary::LogCriticalSynchronous_BFL(const FString szText, const FString szdictMeta)
 {
-	return LogCritical(FStringToChar16Ptr(szText));
+	return LogCritical(FStringToChar16Ptr(szText), FStringToChar16Ptr(szdictMeta));
 }
 
-int UIXRBlueprintLibrary::LogCritical_BFL(const FString szText)
+int UIXRBlueprintLibrary::LogCritical_BFL(const FString szText, const FString szdictMeta)
 {
-	return LogCritical(FStringToChar16Ptr(szText));
+	return LogCritical(FStringToChar16Ptr(szText), FStringToChar16Ptr(szdictMeta));
 }
+
+// ---
 
 int UIXRBlueprintLibrary::EventSynchronous_BFL(const FString szMessage, const FString szdictMeta)
 {
@@ -328,14 +330,14 @@ int UIXRBlueprintLibrary::AddAIProxy_BFL(const FString szPrompt, const FString s
 	return AddAIProxy(FStringToChar16Ptr(szPrompt), FStringToChar16Ptr(szPastMessages), FStringToChar16Ptr(szLMMProvider));
 }
 
-int UIXRBlueprintLibrary::AddTelemetryEntrySynchronous_BFL(const FString szName, const FString szdictData)
+int UIXRBlueprintLibrary::AddTelemetryEntrySynchronous_BFL(const FString szName, const FString szdictMeta)
 {
-	return AddTelemetryEntrySynchronous(FStringToChar16Ptr(szName), FStringToChar16Ptr(szdictData));
+	return AddTelemetryEntrySynchronous(FStringToChar16Ptr(szName), FStringToChar16Ptr(szdictMeta));
 }
 
-int UIXRBlueprintLibrary::AddTelemetryEntry_BFL(const FString szName, const FString szdictData)
+int UIXRBlueprintLibrary::AddTelemetryEntry_BFL(const FString szName, const FString szdictMeta)
 {
-	return AddTelemetryEntry(FStringToChar16Ptr(szName), FStringToChar16Ptr(szdictData));
+	return AddTelemetryEntry(FStringToChar16Ptr(szName), FStringToChar16Ptr(szdictMeta));
 }
 
 bool UIXRBlueprintLibrary::PlatformIsWindows_BFL()

--- a/Source/IXRLib/Public/IXRBlueprintLibrary.h
+++ b/Source/IXRLib/Public/IXRBlueprintLibrary.h
@@ -60,34 +60,34 @@ public:
 	static void UnCaptureTimeStamp_BFL();
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
-	static int LogDebugSynchronous_BFL(const FString szText);
+	static int LogDebugSynchronous_BFL(const FString szText, const FString szdictMeta);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
-	static int LogDebug_BFL(const FString szText);
+	static int LogDebug_BFL(const FString szText, const FString szdictMeta);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
-	static int LogInfoSynchronous_BFL(const FString szText);
+	static int LogInfoSynchronous_BFL(const FString szText, const FString szdictMeta);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
-	static int LogInfo_BFL(const FString szText);
+	static int LogInfo_BFL(const FString szText, const FString szdictMeta);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
-	static int LogWarnSynchronous_BFL(const FString szText);
+	static int LogWarnSynchronous_BFL(const FString szText, const FString szdictMeta);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
-	static int LogWarn_BFL(const FString szText);
+	static int LogWarn_BFL(const FString szText, const FString szdictMeta);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
-	static int LogErrorSynchronous_BFL(const FString szText);
+	static int LogErrorSynchronous_BFL(const FString szText, const FString szdictMeta);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
-	static int LogError_BFL(const FString szText);
+	static int LogError_BFL(const FString szText, const FString szdictMeta);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
-	static int LogCriticalSynchronous_BFL(const FString szText);
+	static int LogCriticalSynchronous_BFL(const FString szText, const FString szdictMeta);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
-	static int LogCritical_BFL(const FString szText);
+	static int LogCritical_BFL(const FString szText, const FString szdictMeta);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
 	static int EventSynchronous_BFL(const FString szMessage, const FString szdictMeta);
@@ -126,10 +126,10 @@ public:
 	static int AddAIProxy_BFL(const FString szPrompt, const FString szPastMessages, const FString szLMMProvider);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
-	static int AddTelemetryEntrySynchronous_BFL(const FString szName, const FString szdictData);
+	static int AddTelemetryEntrySynchronous_BFL(const FString szName, const FString szdictMeta);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
-	static int AddTelemetryEntry_BFL(const FString szName, const FString szdictData);
+	static int AddTelemetryEntry_BFL(const FString szName, const FString szdictMeta);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
 	static bool PlatformIsWindows_BFL();

--- a/Source/ThirdParty/Android/includes/Interface.h
+++ b/Source/ThirdParty/Android/includes/Interface.h
@@ -194,16 +194,16 @@ extern "C" DLLEXPORT uint32_t ForceSendUnsentSynchronous();
 extern "C" DLLEXPORT void CaptureTimeStamp();
 extern "C" DLLEXPORT void UnCaptureTimeStamp();
 // ---
-extern "C" DLLEXPORT uint32_t LogDebugSynchronous(const char16_t* szText);
-extern "C" DLLEXPORT uint32_t LogDebug(const char16_t* szText);
-extern "C" DLLEXPORT uint32_t LogInfoSynchronous(const char16_t* szText);
-extern "C" DLLEXPORT uint32_t LogInfo(const char16_t* szText);
-extern "C" DLLEXPORT uint32_t LogWarnSynchronous(const char16_t* szText);
-extern "C" DLLEXPORT uint32_t LogWarn(const char16_t* szText);
-extern "C" DLLEXPORT uint32_t LogErrorSynchronous(const char16_t* szText);
-extern "C" DLLEXPORT uint32_t LogError(const char16_t* szText);
-extern "C" DLLEXPORT uint32_t LogCriticalSynchronous(const char16_t* szText);
-extern "C" DLLEXPORT uint32_t LogCritical(const char16_t* szText);
+extern "C" DLLEXPORT uint32_t LogDebugSynchronous(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogDebug(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogInfoSynchronous(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogInfo(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogWarnSynchronous(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogWarn(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogErrorSynchronous(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogError(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogCriticalSynchronous(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogCritical(const char16_t* szText, const char16_t* szdictMeta);
 // ---
 extern "C" DLLEXPORT uint32_t EventSynchronous(const char16_t* szMessage, const char16_t* szdictMeta);
 extern "C" DLLEXPORT uint32_t Event(const char16_t* szMessage, const char16_t* szdictMeta);
@@ -223,8 +223,8 @@ extern "C" DLLEXPORT uint32_t EventLevelComplete(const char16_t* szLevelName, co
 extern "C" DLLEXPORT uint32_t AddAIProxySynchronous(const char16_t* szPrompt, const char16_t* szPastMessages, const char16_t* szLMMProvider);
 extern "C" DLLEXPORT uint32_t AddAIProxy(const char16_t* szPrompt, const char16_t* szPastMessages, const char16_t* szLMMProvider);
 // ---
-extern "C" DLLEXPORT uint32_t AddTelemetryEntrySynchronous(const char16_t* szName, const char16_t* szdictData);
-extern "C" DLLEXPORT uint32_t AddTelemetryEntry(const char16_t* szName, const char16_t* szdictData);
+extern "C" DLLEXPORT uint32_t AddTelemetryEntrySynchronous(const char16_t* szName, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t AddTelemetryEntry(const char16_t* szName, const char16_t* szdictMeta);
 // ---
 extern "C" DLLEXPORT bool PlatformIsWindows();
 // --- Authentication fields.

--- a/Source/ThirdParty/Win64/includes/Interface.h
+++ b/Source/ThirdParty/Win64/includes/Interface.h
@@ -194,16 +194,16 @@ extern "C" DLLEXPORT uint32_t ForceSendUnsentSynchronous();
 extern "C" DLLEXPORT void CaptureTimeStamp();
 extern "C" DLLEXPORT void UnCaptureTimeStamp();
 // ---
-extern "C" DLLEXPORT uint32_t LogDebugSynchronous(const char16_t* szText);
-extern "C" DLLEXPORT uint32_t LogDebug(const char16_t* szText);
-extern "C" DLLEXPORT uint32_t LogInfoSynchronous(const char16_t* szText);
-extern "C" DLLEXPORT uint32_t LogInfo(const char16_t* szText);
-extern "C" DLLEXPORT uint32_t LogWarnSynchronous(const char16_t* szText);
-extern "C" DLLEXPORT uint32_t LogWarn(const char16_t* szText);
-extern "C" DLLEXPORT uint32_t LogErrorSynchronous(const char16_t* szText);
-extern "C" DLLEXPORT uint32_t LogError(const char16_t* szText);
-extern "C" DLLEXPORT uint32_t LogCriticalSynchronous(const char16_t* szText);
-extern "C" DLLEXPORT uint32_t LogCritical(const char16_t* szText);
+extern "C" DLLEXPORT uint32_t LogDebugSynchronous(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogDebug(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogInfoSynchronous(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogInfo(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogWarnSynchronous(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogWarn(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogErrorSynchronous(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogError(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogCriticalSynchronous(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogCritical(const char16_t* szText, const char16_t* szdictMeta);
 // ---
 extern "C" DLLEXPORT uint32_t EventSynchronous(const char16_t* szMessage, const char16_t* szdictMeta);
 extern "C" DLLEXPORT uint32_t Event(const char16_t* szMessage, const char16_t* szdictMeta);
@@ -223,8 +223,8 @@ extern "C" DLLEXPORT uint32_t EventLevelComplete(const char16_t* szLevelName, co
 extern "C" DLLEXPORT uint32_t AddAIProxySynchronous(const char16_t* szPrompt, const char16_t* szPastMessages, const char16_t* szLMMProvider);
 extern "C" DLLEXPORT uint32_t AddAIProxy(const char16_t* szPrompt, const char16_t* szPastMessages, const char16_t* szLMMProvider);
 // ---
-extern "C" DLLEXPORT uint32_t AddTelemetryEntrySynchronous(const char16_t* szName, const char16_t* szdictData);
-extern "C" DLLEXPORT uint32_t AddTelemetryEntry(const char16_t* szName, const char16_t* szdictData);
+extern "C" DLLEXPORT uint32_t AddTelemetryEntrySynchronous(const char16_t* szName, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t AddTelemetryEntry(const char16_t* szName, const char16_t* szdictMeta);
 // ---
 extern "C" DLLEXPORT bool PlatformIsWindows();
 // --- Authentication fields.


### PR DESCRIPTION
…rged main into development which curiously existed already but was empty except for README.md.  Then branched this branch off it in order to port over the dictMeta factoring changes from iXRLib and iXRLibForWebXR.  As Віталій created the plugin to wrap the interface.cpp/h layer, the port was actually very straightforward and simple.  Argues that maybe we want to simply go forward with that in perpetuity if there are no performance issues (as opposed to a static-lib approach that goes deeper into the mines of iXRLib and would be much more sticky to co-maintain).
^^^ Commit comment.
vvv MJP extra (summary):
PR for sanity check... this is a mergeover of basically Interface.cpp/h from iXRLib of the dictMeta factoring Nick/Alejandro/MJP discussed then implemented which due to this plugin interacting with iXRLib exclusively at that layer is that simple.  Review should be basically looking for stupid mistakes.