### PR TITLE
iXRLibForUnreal, RENAME_SYNCHRONOUS_EMPTY_DICTMETA:  After philosophi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ All the wrapped methods are static and have a UFUNCTION(BlueprintCallable) macro
 ![](https://github.com/informXR/iXRLibForUnreal/blob/main/ReadmeImages/blueprint.png?raw=true)
 
 ***C++***  
-UIXRBlueprintLibrary::LogDebugSynchronous\_BFL(MyString)  
+UIXRBlueprintLibrary::LogDebug\_BFL(MyString)  

--- a/Source/IXRLib/Private/IXRBlueprintLibrary.cpp
+++ b/Source/IXRLib/Private/IXRBlueprintLibrary.cpp
@@ -155,9 +155,9 @@ int UIXRBlueprintLibrary::ReAuthenticate_BFL(const bool bObtainAuthSecret)
 	return ReAuthenticate(bObtainAuthSecret);
 }
 
-int UIXRBlueprintLibrary::ForceSendUnsentSynchronous_BFL()
+int UIXRBlueprintLibrary::ForceSendUnsent_BFL()
 {
-	return ForceSendUnsentSynchronous();
+	return ForceSendUnsent();
 }
 
 void UIXRBlueprintLibrary::CaptureTimeStamp_BFL()
@@ -170,19 +170,14 @@ void UIXRBlueprintLibrary::UnCaptureTimeStamp_BFL()
 	UnCaptureTimeStamp();
 }
 
-int UIXRBlueprintLibrary::LogDebugSynchronous_BFL(const FString szText, const FString szdictMeta)
-{
-	return LogDebugSynchronous(FStringToChar16Ptr(szText), FStringToChar16Ptr(szdictMeta));
-}
-
 int UIXRBlueprintLibrary::LogDebug_BFL(const FString szText, const FString szdictMeta)
 {
 	return LogDebug(FStringToChar16Ptr(szText), FStringToChar16Ptr(szdictMeta));
 }
 
-int UIXRBlueprintLibrary::LogInfoSynchronous_BFL(const FString szText, const FString szdictMeta)
+int UIXRBlueprintLibrary::LogDebugDeferred_BFL(const FString szText, const FString szdictMeta)
 {
-	return LogInfo(FStringToChar16Ptr(szText), FStringToChar16Ptr(szdictMeta));
+	return LogDebugDeferred(FStringToChar16Ptr(szText), FStringToChar16Ptr(szdictMeta));
 }
 
 int UIXRBlueprintLibrary::LogInfo_BFL(const FString szText, const FString szdictMeta)
@@ -190,9 +185,9 @@ int UIXRBlueprintLibrary::LogInfo_BFL(const FString szText, const FString szdict
 	return LogInfo(FStringToChar16Ptr(szText), FStringToChar16Ptr(szdictMeta));
 }
 
-int UIXRBlueprintLibrary::LogWarnSynchronous_BFL(const FString szText, const FString szdictMeta)
+int UIXRBlueprintLibrary::LogInfoDeferred_BFL(const FString szText, const FString szdictMeta)
 {
-	return LogWarnSynchronous(FStringToChar16Ptr(szText), FStringToChar16Ptr(szdictMeta));
+	return LogInfoDeferred(FStringToChar16Ptr(szText), FStringToChar16Ptr(szdictMeta));
 }
 
 int UIXRBlueprintLibrary::LogWarn_BFL(const FString szText, const FString szdictMeta)
@@ -200,9 +195,9 @@ int UIXRBlueprintLibrary::LogWarn_BFL(const FString szText, const FString szdict
 	return LogWarn(FStringToChar16Ptr(szText), FStringToChar16Ptr(szdictMeta));
 }
 
-int UIXRBlueprintLibrary::LogErrorSynchronous_BFL(const FString szText, const FString szdictMeta)
+int UIXRBlueprintLibrary::LogWarnDeferred_BFL(const FString szText, const FString szdictMeta)
 {
-	return LogError(FStringToChar16Ptr(szText), FStringToChar16Ptr(szdictMeta));
+	return LogWarnDeferred(FStringToChar16Ptr(szText), FStringToChar16Ptr(szdictMeta));
 }
 
 int UIXRBlueprintLibrary::LogError_BFL(const FString szText, const FString szdictMeta)
@@ -210,9 +205,9 @@ int UIXRBlueprintLibrary::LogError_BFL(const FString szText, const FString szdic
 	return LogError(FStringToChar16Ptr(szText), FStringToChar16Ptr(szdictMeta));
 }
 
-int UIXRBlueprintLibrary::LogCriticalSynchronous_BFL(const FString szText, const FString szdictMeta)
+int UIXRBlueprintLibrary::LogErrorDeferred_BFL(const FString szText, const FString szdictMeta)
 {
-	return LogCritical(FStringToChar16Ptr(szText), FStringToChar16Ptr(szdictMeta));
+	return LogErrorDeferred(FStringToChar16Ptr(szText), FStringToChar16Ptr(szdictMeta));
 }
 
 int UIXRBlueprintLibrary::LogCritical_BFL(const FString szText, const FString szdictMeta)
@@ -220,16 +215,21 @@ int UIXRBlueprintLibrary::LogCritical_BFL(const FString szText, const FString sz
 	return LogCritical(FStringToChar16Ptr(szText), FStringToChar16Ptr(szdictMeta));
 }
 
-// ---
-
-int UIXRBlueprintLibrary::EventSynchronous_BFL(const FString szMessage, const FString szdictMeta)
+int UIXRBlueprintLibrary::LogCriticalDeferred_BFL(const FString szText, const FString szdictMeta)
 {
-	return EventSynchronous(FStringToChar16Ptr(szMessage), FStringToChar16Ptr(szdictMeta));
+	return LogCriticalDeferred(FStringToChar16Ptr(szText), FStringToChar16Ptr(szdictMeta));
 }
+
+// ---
 
 int UIXRBlueprintLibrary::Event_BFL(const FString szMessage, const FString szdictMeta)
 {
 	return Event(FStringToChar16Ptr(szMessage), FStringToChar16Ptr(szdictMeta));
+}
+
+int UIXRBlueprintLibrary::EventDeferred_BFL(const FString szMessage, const FString szdictMeta)
+{
+	return EventDeferred(FStringToChar16Ptr(szMessage), FStringToChar16Ptr(szdictMeta));
 }
 
 int UIXRBlueprintLibrary::EventAssessmentStart_BFL(const FString szAssessmentName, const FString szdictMeta)
@@ -318,26 +318,26 @@ void UIXRBlueprintLibrary::SetAppConfigAuthMechanism_BFL(const FString szdictVal
 	set_AppConfigAuthMechanism(FStringToChar16Ptr(szdictValue));
 }
 
-int UIXRBlueprintLibrary::AddAIProxySynchronous_BFL(const FString szPrompt, const FString szPastMessages,
-                                                    const FString szLMMProvider)
-{
-	return AddAIProxySynchronous(FStringToChar16Ptr(szPrompt), FStringToChar16Ptr(szPastMessages), FStringToChar16Ptr(szLMMProvider));
-}
-
 int UIXRBlueprintLibrary::AddAIProxy_BFL(const FString szPrompt, const FString szPastMessages,
-	const FString szLMMProvider)
+                                                    const FString szLMMProvider)
 {
 	return AddAIProxy(FStringToChar16Ptr(szPrompt), FStringToChar16Ptr(szPastMessages), FStringToChar16Ptr(szLMMProvider));
 }
 
-int UIXRBlueprintLibrary::AddTelemetryEntrySynchronous_BFL(const FString szName, const FString szdictMeta)
+int UIXRBlueprintLibrary::AddAIProxyDeferred_BFL(const FString szPrompt, const FString szPastMessages,
+	const FString szLMMProvider)
 {
-	return AddTelemetryEntrySynchronous(FStringToChar16Ptr(szName), FStringToChar16Ptr(szdictMeta));
+	return AddAIProxyDeferred(FStringToChar16Ptr(szPrompt), FStringToChar16Ptr(szPastMessages), FStringToChar16Ptr(szLMMProvider));
 }
 
 int UIXRBlueprintLibrary::AddTelemetryEntry_BFL(const FString szName, const FString szdictMeta)
 {
 	return AddTelemetryEntry(FStringToChar16Ptr(szName), FStringToChar16Ptr(szdictMeta));
+}
+
+int UIXRBlueprintLibrary::AddTelemetryEntryDeferred_BFL(const FString szName, const FString szdictMeta)
+{
+	return AddTelemetryEntryDeferred(FStringToChar16Ptr(szName), FStringToChar16Ptr(szdictMeta));
 }
 
 bool UIXRBlueprintLibrary::PlatformIsWindows_BFL()
@@ -681,34 +681,42 @@ void UIXRBlueprintLibrary::SetServingCSharp_BFL(const bool bServingCSharp)
 
 bool UIXRBlueprintLibrary::GetNextDiagnosticString_BFL(FString& pbstrString)
 {
-	char16_t* char16Str = nullptr;
+	char16_t	*char16Str = nullptr;
+	bool		result = GetNextDiagnosticString(&char16Str);
 
-	bool result = GetNextDiagnosticString(&char16Str);
-
-	if (result && char16Str != nullptr) 
+	if (result && char16Str != nullptr)
+	{
 		pbstrString = FString(reinterpret_cast<const TCHAR*>(char16Str));
+	}
 	else
+	{
 		pbstrString = FString();
-
+	}
 	return result;
 
 }
 
 uint8 UIXRBlueprintLibrary::HTTPGet_BFL(const FString bstrUrl, FString& pbstrResponse)
 {
-	char16_t* char16Str = nullptr;
-	auto result = HTTPGet(FStringToChar16Ptr(bstrUrl), &char16Str);
-	if (char16Str != nullptr) 
+	char16_t	*char16Str = nullptr;
+	auto		result = HTTPGet(FStringToChar16Ptr(bstrUrl), &char16Str);
+
+	if (char16Str != nullptr)
+	{
 		pbstrResponse = FString(reinterpret_cast<const TCHAR*>(char16Str));
+	}
 	return 0;
 }
 
 uint8 UIXRBlueprintLibrary::HTTPPost_BFL(const FString bstrUrl, FString& pbstrResponse)
 {
-	char16_t* char16Str = nullptr;
-	auto result = HTTPPost(FStringToChar16Ptr(bstrUrl), &char16Str);
-	if (char16Str != nullptr) 
+	char16_t	*char16Str = nullptr;
+	auto		result = HTTPPost(FStringToChar16Ptr(bstrUrl), &char16Str);
+
+	if (char16Str != nullptr)
+	{
 		pbstrResponse = FString(reinterpret_cast<const TCHAR*>(char16Str));
+	}
 	return 0;
 }
 

--- a/Source/IXRLib/Public/IXRBlueprintLibrary.h
+++ b/Source/IXRLib/Public/IXRBlueprintLibrary.h
@@ -51,7 +51,7 @@ public:
 	static int ReAuthenticate_BFL(const bool bObtainAuthSecret);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
-	static int ForceSendUnsentSynchronous_BFL();
+	static int ForceSendUnsent_BFL();
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
 	static void CaptureTimeStamp_BFL();
@@ -60,40 +60,40 @@ public:
 	static void UnCaptureTimeStamp_BFL();
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
-	static int LogDebugSynchronous_BFL(const FString szText, const FString szdictMeta);
-	
-	UFUNCTION(BlueprintCallable, Category = "iXRLib")
 	static int LogDebug_BFL(const FString szText, const FString szdictMeta);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
-	static int LogInfoSynchronous_BFL(const FString szText, const FString szdictMeta);
+	static int LogDebugDeferred_BFL(const FString szText, const FString szdictMeta);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
 	static int LogInfo_BFL(const FString szText, const FString szdictMeta);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
-	static int LogWarnSynchronous_BFL(const FString szText, const FString szdictMeta);
+	static int LogInfoDeferred_BFL(const FString szText, const FString szdictMeta);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
 	static int LogWarn_BFL(const FString szText, const FString szdictMeta);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
-	static int LogErrorSynchronous_BFL(const FString szText, const FString szdictMeta);
+	static int LogWarnDeferred_BFL(const FString szText, const FString szdictMeta);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
 	static int LogError_BFL(const FString szText, const FString szdictMeta);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
-	static int LogCriticalSynchronous_BFL(const FString szText, const FString szdictMeta);
+	static int LogErrorDeferred_BFL(const FString szText, const FString szdictMeta);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
 	static int LogCritical_BFL(const FString szText, const FString szdictMeta);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
-	static int EventSynchronous_BFL(const FString szMessage, const FString szdictMeta);
+	static int LogCriticalDeferred_BFL(const FString szText, const FString szdictMeta);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
 	static int Event_BFL(const FString szMessage, const FString szdictMeta);
+	
+	UFUNCTION(BlueprintCallable, Category = "iXRLib")
+	static int EventDeferred_BFL(const FString szMessage, const FString szdictMeta);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
 	static int EventAssessmentStart_BFL(const FString szAssessmentName, const FString szdictMeta);
@@ -120,16 +120,16 @@ public:
 	static int EventLevelComplete_BFL(const FString szLevelName, const FString szScore, const FString szdictMeta);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
-	static int AddAIProxySynchronous_BFL(const FString szPrompt, const FString szPastMessages, const FString szLMMProvider);
-	
-	UFUNCTION(BlueprintCallable, Category = "iXRLib")
 	static int AddAIProxy_BFL(const FString szPrompt, const FString szPastMessages, const FString szLMMProvider);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
-	static int AddTelemetryEntrySynchronous_BFL(const FString szName, const FString szdictMeta);
+	static int AddAIProxyDeferred_BFL(const FString szPrompt, const FString szPastMessages, const FString szLMMProvider);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
 	static int AddTelemetryEntry_BFL(const FString szName, const FString szdictMeta);
+	
+	UFUNCTION(BlueprintCallable, Category = "iXRLib")
+	static int AddTelemetryEntryDeferred_BFL(const FString szName, const FString szdictMeta);
 	
 	UFUNCTION(BlueprintCallable, Category = "iXRLib")
 	static bool PlatformIsWindows_BFL();

--- a/Source/ThirdParty/Android/includes/Interface.h
+++ b/Source/ThirdParty/Android/includes/Interface.h
@@ -189,24 +189,24 @@ extern "C" DLLEXPORT void iXRLibInitEnd();
 extern "C" DLLEXPORT uint32_t Authenticate(const char16_t* szAppId, const char16_t* szOrgId, const char16_t* szDeviceId, const char16_t* szAuthSecret, const uint32_t ePartner);
 extern "C" DLLEXPORT uint32_t FinalAuthenticate();
 extern "C" DLLEXPORT uint32_t ReAuthenticate(const bool bObtainAuthSecret);
-extern "C" DLLEXPORT uint32_t ForceSendUnsentSynchronous();
+extern "C" DLLEXPORT uint32_t ForceSendUnsent();
 // ---
 extern "C" DLLEXPORT void CaptureTimeStamp();
 extern "C" DLLEXPORT void UnCaptureTimeStamp();
 // ---
-extern "C" DLLEXPORT uint32_t LogDebugSynchronous(const char16_t* szText, const char16_t* szdictMeta);
 extern "C" DLLEXPORT uint32_t LogDebug(const char16_t* szText, const char16_t* szdictMeta);
-extern "C" DLLEXPORT uint32_t LogInfoSynchronous(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogDebugDeferred(const char16_t* szText, const char16_t* szdictMeta);
 extern "C" DLLEXPORT uint32_t LogInfo(const char16_t* szText, const char16_t* szdictMeta);
-extern "C" DLLEXPORT uint32_t LogWarnSynchronous(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogInfoDeferred(const char16_t* szText, const char16_t* szdictMeta);
 extern "C" DLLEXPORT uint32_t LogWarn(const char16_t* szText, const char16_t* szdictMeta);
-extern "C" DLLEXPORT uint32_t LogErrorSynchronous(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogWarnDeferred(const char16_t* szText, const char16_t* szdictMeta);
 extern "C" DLLEXPORT uint32_t LogError(const char16_t* szText, const char16_t* szdictMeta);
-extern "C" DLLEXPORT uint32_t LogCriticalSynchronous(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogErrorDeferred(const char16_t* szText, const char16_t* szdictMeta);
 extern "C" DLLEXPORT uint32_t LogCritical(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogCriticalDeferred(const char16_t* szText, const char16_t* szdictMeta);
 // ---
-extern "C" DLLEXPORT uint32_t EventSynchronous(const char16_t* szMessage, const char16_t* szdictMeta);
 extern "C" DLLEXPORT uint32_t Event(const char16_t* szMessage, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t EventDeferred(const char16_t* szMessage, const char16_t* szdictMeta);
 // --- Convenient wrappers for particular forms of events.
 extern "C" DLLEXPORT uint32_t EventAssessmentStart(const char16_t* szAssessmentName, const char16_t* szdictMeta);
 extern "C" DLLEXPORT uint32_t EventAssessmentComplete(const char16_t* szAssessmentName, const char16_t* szScore, const uint32_t eResultOptions, const char16_t* szdictMeta);
@@ -220,11 +220,11 @@ extern "C" DLLEXPORT uint32_t EventInteractionComplete(const char16_t* szInterac
 extern "C" DLLEXPORT uint32_t EventLevelStart(const char16_t* szLevelName, const char16_t* szdictMeta);
 extern "C" DLLEXPORT uint32_t EventLevelComplete(const char16_t* szLevelName, const char16_t* szScore, const char16_t* szdictMeta);
 // ---
-extern "C" DLLEXPORT uint32_t AddAIProxySynchronous(const char16_t* szPrompt, const char16_t* szPastMessages, const char16_t* szLMMProvider);
 extern "C" DLLEXPORT uint32_t AddAIProxy(const char16_t* szPrompt, const char16_t* szPastMessages, const char16_t* szLMMProvider);
+extern "C" DLLEXPORT uint32_t AddAIProxyDeferred(const char16_t* szPrompt, const char16_t* szPastMessages, const char16_t* szLMMProvider);
 // ---
-extern "C" DLLEXPORT uint32_t AddTelemetryEntrySynchronous(const char16_t* szName, const char16_t* szdictMeta);
 extern "C" DLLEXPORT uint32_t AddTelemetryEntry(const char16_t* szName, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t AddTelemetryEntryDeferred(const char16_t* szName, const char16_t* szdictMeta);
 // ---
 extern "C" DLLEXPORT bool PlatformIsWindows();
 // --- Authentication fields.

--- a/Source/ThirdParty/Win64/includes/Interface.h
+++ b/Source/ThirdParty/Win64/includes/Interface.h
@@ -189,24 +189,24 @@ extern "C" DLLEXPORT void iXRLibInitEnd();
 extern "C" DLLEXPORT uint32_t Authenticate(const char16_t* szAppId, const char16_t* szOrgId, const char16_t* szDeviceId, const char16_t* szAuthSecret, const uint32_t ePartner);
 extern "C" DLLEXPORT uint32_t FinalAuthenticate();
 extern "C" DLLEXPORT uint32_t ReAuthenticate(const bool bObtainAuthSecret);
-extern "C" DLLEXPORT uint32_t ForceSendUnsentSynchronous();
+extern "C" DLLEXPORT uint32_t ForceSendUnsent();
 // ---
 extern "C" DLLEXPORT void CaptureTimeStamp();
 extern "C" DLLEXPORT void UnCaptureTimeStamp();
 // ---
-extern "C" DLLEXPORT uint32_t LogDebugSynchronous(const char16_t* szText, const char16_t* szdictMeta);
 extern "C" DLLEXPORT uint32_t LogDebug(const char16_t* szText, const char16_t* szdictMeta);
-extern "C" DLLEXPORT uint32_t LogInfoSynchronous(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogDebugDeferred(const char16_t* szText, const char16_t* szdictMeta);
 extern "C" DLLEXPORT uint32_t LogInfo(const char16_t* szText, const char16_t* szdictMeta);
-extern "C" DLLEXPORT uint32_t LogWarnSynchronous(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogInfoDeferred(const char16_t* szText, const char16_t* szdictMeta);
 extern "C" DLLEXPORT uint32_t LogWarn(const char16_t* szText, const char16_t* szdictMeta);
-extern "C" DLLEXPORT uint32_t LogErrorSynchronous(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogWarnDeferred(const char16_t* szText, const char16_t* szdictMeta);
 extern "C" DLLEXPORT uint32_t LogError(const char16_t* szText, const char16_t* szdictMeta);
-extern "C" DLLEXPORT uint32_t LogCriticalSynchronous(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogErrorDeferred(const char16_t* szText, const char16_t* szdictMeta);
 extern "C" DLLEXPORT uint32_t LogCritical(const char16_t* szText, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t LogCriticalDeferred(const char16_t* szText, const char16_t* szdictMeta);
 // ---
-extern "C" DLLEXPORT uint32_t EventSynchronous(const char16_t* szMessage, const char16_t* szdictMeta);
 extern "C" DLLEXPORT uint32_t Event(const char16_t* szMessage, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t EventDeferred(const char16_t* szMessage, const char16_t* szdictMeta);
 // --- Convenient wrappers for particular forms of events.
 extern "C" DLLEXPORT uint32_t EventAssessmentStart(const char16_t* szAssessmentName, const char16_t* szdictMeta);
 extern "C" DLLEXPORT uint32_t EventAssessmentComplete(const char16_t* szAssessmentName, const char16_t* szScore, const uint32_t eResultOptions, const char16_t* szdictMeta);
@@ -220,11 +220,11 @@ extern "C" DLLEXPORT uint32_t EventInteractionComplete(const char16_t* szInterac
 extern "C" DLLEXPORT uint32_t EventLevelStart(const char16_t* szLevelName, const char16_t* szdictMeta);
 extern "C" DLLEXPORT uint32_t EventLevelComplete(const char16_t* szLevelName, const char16_t* szScore, const char16_t* szdictMeta);
 // ---
-extern "C" DLLEXPORT uint32_t AddAIProxySynchronous(const char16_t* szPrompt, const char16_t* szPastMessages, const char16_t* szLMMProvider);
 extern "C" DLLEXPORT uint32_t AddAIProxy(const char16_t* szPrompt, const char16_t* szPastMessages, const char16_t* szLMMProvider);
+extern "C" DLLEXPORT uint32_t AddAIProxyDeferred(const char16_t* szPrompt, const char16_t* szPastMessages, const char16_t* szLMMProvider);
 // ---
-extern "C" DLLEXPORT uint32_t AddTelemetryEntrySynchronous(const char16_t* szName, const char16_t* szdictMeta);
 extern "C" DLLEXPORT uint32_t AddTelemetryEntry(const char16_t* szName, const char16_t* szdictMeta);
+extern "C" DLLEXPORT uint32_t AddTelemetryEntryDeferred(const char16_t* szName, const char16_t* szdictMeta);
 // ---
 extern "C" DLLEXPORT bool PlatformIsWindows();
 // --- Authentication fields.


### PR DESCRIPTION
…zing with Nick, we decided that what were being called XXXSynchronous() are the primary versions of the functions and therefore should not have the Synchronous as that is confusing with respect to C# coding conventions with async and await.  Hence the opposite convention:  the primaries are simply XXX() (Event(), LogCritical(), ...) and the ones that return immediately and allow for a callback in the C++ code (which were of the form XXX()) will now be of the form XXXDeferred().